### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -1,4 +1,6 @@
 name: Test and coverage
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/quelixir/secad/security/code-scanning/3](https://github.com/quelixir/secad/security/code-scanning/3)

To fix the problem, explicitly set the `permissions` key at the workflow level (top-level, just after the `name` and before `on`). This will apply the least privilege principle to all jobs in the workflow. The minimal required permission for most test and coverage workflows is `contents: read`, which allows the workflow to read repository contents but not write to them. If any step in the workflow requires additional permissions (such as writing to pull requests), those can be added as needed, but for this workflow, `contents: read` is sufficient. The change should be made at the top of `.github/workflows/test-and-coverage.yml`, after the `name` field and before the `on` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
